### PR TITLE
Tenant View for Multi-Tenant SSO

### DIFF
--- a/docs/tethys_portal/configuration.rst
+++ b/docs/tethys_portal/configuration.rst
@@ -122,6 +122,7 @@ The following is a list of keys that can be added to the :file:`portal_config.ym
 
   * **OAUTH_CONFIG**:
 
+    * **SSO_TENANT_ALIAS**: Alias to use for "Tenant" on the /accounts/tenant/ page. This page is only needed when using Multi-Tenant SSO features. Defaults to "Tenant".
     * **SOCIAL_AUTH_AZUREAD_OAUTH2_KEY**: Key for authenticating with Azure Active Directory using their OAuth2 service. See :ref:`social_auth_azuread` SSO Setup.
     * **SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET**: Secret for authenticating with Azure Active Directory using their OAuth2 service. See :ref:`social_auth_azuread` SSO Setup.
     * **SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY**: Key for authenticating with Azure Active Directory against a single Tenant/Active Directory using their OAuth2 service. See :ref:`social_auth_azuread` SSO Setup.

--- a/tests/unit_tests/test_tethys_portal/test_forms.py
+++ b/tests/unit_tests/test_tethys_portal/test_forms.py
@@ -2,7 +2,7 @@ import os
 from importlib import reload
 from django.test import TestCase
 from captcha.models import CaptchaStore
-import tethys_portal.forms
+import tethys_portal.forms as tp_forms
 from django.contrib.auth.models import User
 from django import forms
 from unittest import mock
@@ -27,8 +27,8 @@ class TethysPortalFormsTests(TestCase):
         login_data = {'username': 'admin', 'password': 'test1231'}
 
         with self.settings(ENABLE_CAPTCHA=False):
-            reload(tethys_portal.forms)
-            login_form = tethys_portal.forms.LoginForm(login_data)
+            reload(tp_forms)
+            login_form = tp_forms.LoginForm(login_data)
             self.assertTrue(login_form.is_valid())
 
     def test_LoginForm_simple_captcha(self):
@@ -36,8 +36,8 @@ class TethysPortalFormsTests(TestCase):
         login_data = {'username': 'admin', 'password': 'test1231', 'captcha_0': self.hashkey,
                       'captcha_1': self.response}
         with self.settings(ENABLE_CAPTCHA=True, RECAPTCHA_PRIVATE_KEY='', RECAPTCHA_PUBLIC_KEY=''):
-            reload(tethys_portal.forms)
-            login_form = tethys_portal.forms.LoginForm(login_data)
+            reload(tp_forms)
+            login_form = tp_forms.LoginForm(login_data)
             self.assertTrue(login_form.is_valid())
 
     def test_LoginForm_recaptcha(self):
@@ -46,8 +46,8 @@ class TethysPortalFormsTests(TestCase):
 
         with self.settings(ENABLE_CAPTCHA=True, RECAPTCHA_PRIVATE_KEY='my-fake-private-key',
                            RECAPTCHA_PUBLIC_KEY='my-fake-public-key'):
-            reload(tethys_portal.forms)
-            login_form = tethys_portal.forms.LoginForm(login_data)
+            reload(tp_forms)
+            login_form = tp_forms.LoginForm(login_data)
             self.assertTrue(login_form.is_valid())
 
         del os.environ['RECAPTCHA_DISABLE']
@@ -55,7 +55,7 @@ class TethysPortalFormsTests(TestCase):
     def test_LoginForm_invalid_username(self):
         login_data = {'username': '$!admin', 'password': 'test1231', 'captcha_0': self.hashkey,
                       'captcha_1': self.response}
-        login_form = tethys_portal.forms.LoginForm(login_data)
+        login_form = tp_forms.LoginForm(login_data)
         err_msg = "This value may contain only letters, numbers and @/./+/-/_ characters."
         self.assertEqual(login_form.errors['username'], [err_msg])
         self.assertFalse(login_form.is_valid())
@@ -63,15 +63,15 @@ class TethysPortalFormsTests(TestCase):
     def test_LoginForm_invalid_password(self):
         login_data = {'username': 'admin', 'password': '', 'captcha_0': self.hashkey,
                       'captcha_1': self.response}
-        login_form = tethys_portal.forms.LoginForm(login_data)
+        login_form = tp_forms.LoginForm(login_data)
         self.assertFalse(login_form.is_valid())
 
     def test_LoginForm_invalid(self):
         login_invalid_data = {'username': 'admin', 'password': 'test1231', 'captcha_0': self.hashkey,
                               'captcha_1': ''}
         with self.settings(ENABLE_CAPTCHA=True):
-            reload(tethys_portal.forms)
-            login_form = tethys_portal.forms.LoginForm(login_invalid_data)
+            reload(tp_forms)
+            login_form = tp_forms.LoginForm(login_invalid_data)
             self.assertFalse(login_form.is_valid())
 
     # Register Form
@@ -79,13 +79,13 @@ class TethysPortalFormsTests(TestCase):
     def test_RegisterForm(self):
         register_data = {'username': 'user1', 'email': 'foo@aquaveo.com', 'password1': 'abc123',
                          'password2': 'abc123', 'captcha_0': self.hashkey, 'captcha_1': self.response}
-        register_form = tethys_portal.forms.RegisterForm(data=register_data)
+        register_form = tp_forms.RegisterForm(data=register_data)
         self.assertTrue(register_form.is_valid())
 
     def test_RegisterForm_invalid_user(self):
         register_data = {'username': 'user1&!$', 'email': 'foo@aquaveo.com', 'password1': 'abc123',
                          'password2': 'abc123', 'captcha_0': self.hashkey, 'captcha_1': self.response}
-        register_form = tethys_portal.forms.RegisterForm(data=register_data)
+        register_form = tp_forms.RegisterForm(data=register_data)
         err_msg = "This value may contain only letters, numbers and @/./+/-/_ characters."
         self.assertEqual(register_form.errors['username'], [err_msg])
         self.assertFalse(register_form.is_valid())
@@ -94,7 +94,7 @@ class TethysPortalFormsTests(TestCase):
         register_data = {'username': 'user', 'email': 'foo@aquaveo.com', 'password1': 'abc123',
                          'password2': 'abc123', 'captcha_0': self.hashkey, 'captcha_1': self.response}
 
-        register_form = tethys_portal.forms.RegisterForm(data=register_data)
+        register_form = tp_forms.RegisterForm(data=register_data)
 
         self.assertTrue(register_form.is_valid())
 
@@ -106,7 +106,7 @@ class TethysPortalFormsTests(TestCase):
         register_data = {'username': 'user_exist', 'email': 'foo@aquaveo.com', 'password1': 'abc123',
                          'password2': 'abc123', 'captcha_0': self.hashkey, 'captcha_1': self.response}
 
-        register_form = tethys_portal.forms.RegisterForm(data=register_data)
+        register_form = tp_forms.RegisterForm(data=register_data)
 
         # validate form, false because duplicated user
         self.assertFalse(register_form.is_valid())
@@ -120,7 +120,7 @@ class TethysPortalFormsTests(TestCase):
         register_data = {'username': 'user1', 'email': 'foo@aquaveo.com', 'password1': 'abc123',
                          'password2': 'abc123', 'captcha_0': self.hashkey, 'captcha_1': self.response}
 
-        register_form = tethys_portal.forms.RegisterForm(data=register_data)
+        register_form = tp_forms.RegisterForm(data=register_data)
 
         self.assertTrue(register_form.is_valid())
 
@@ -132,7 +132,7 @@ class TethysPortalFormsTests(TestCase):
         register_data = {'username': 'user12', 'email': 'foo_exist@aquaveo.com', 'password1': 'abc123',
                          'password2': 'abc123', 'captcha_0': self.hashkey, 'captcha_1': self.response}
 
-        register_form = tethys_portal.forms.RegisterForm(data=register_data)
+        register_form = tp_forms.RegisterForm(data=register_data)
 
         register_form.is_valid()
 
@@ -149,7 +149,7 @@ class TethysPortalFormsTests(TestCase):
         register_data = {'username': 'user1', 'email': 'foo@aquaveo.com', 'password1': 'abc123',
                          'password2': 'abc123', 'captcha_0': self.hashkey, 'captcha_1': self.response}
 
-        register_form = tethys_portal.forms.RegisterForm(data=register_data)
+        register_form = tp_forms.RegisterForm(data=register_data)
 
         # Check if form is valid and to generate cleaned_data
         self.assertTrue(register_form.is_valid())
@@ -164,7 +164,7 @@ class TethysPortalFormsTests(TestCase):
         register_data = {'username': 'user1', 'email': 'foo@aquaveo.com', 'password1': 'abcd123',
                          'password2': 'abc123', 'captcha_0': self.hashkey, 'captcha_1': self.response}
 
-        register_form = tethys_portal.forms.RegisterForm(data=register_data)
+        register_form = tp_forms.RegisterForm(data=register_data)
 
         # use is_valid to get cleaned_data attributes
         self.assertFalse(register_form.is_valid())
@@ -178,7 +178,7 @@ class TethysPortalFormsTests(TestCase):
         register_data = {'username': 'user1', 'email': 'foo@aquaveo.com', 'password1': 'abc123',
                          'password2': 'abc123', 'captcha_0': self.hashkey, 'captcha_1': self.response}
 
-        register_form = tethys_portal.forms.RegisterForm(data=register_data)
+        register_form = tp_forms.RegisterForm(data=register_data)
 
         ret = register_form.save()
 
@@ -193,21 +193,21 @@ class TethysPortalFormsTests(TestCase):
 
     def test_UserSettingsForm(self):
         user_settings_data = {'first_name': 'fname', 'last_name': 'lname', 'email': 'user@aquaveo.com'}
-        user_settings_form = tethys_portal.forms.UserSettingsForm(data=user_settings_data)
+        user_settings_form = tp_forms.UserSettingsForm(data=user_settings_data)
         self.assertTrue(user_settings_form.is_valid())
 
     # UserPasswordChange Form
 
     def test_UserPasswordChangeForm_valid(self):
         user_password_change_data = {'old_password': 'glass_onion', 'new_password1': 'pass2', 'new_password2': 'pass2'}
-        user_password_change_form = tethys_portal.forms.UserPasswordChangeForm(self.user,
-                                                                               data=user_password_change_data)
+        user_password_change_form = tp_forms.UserPasswordChangeForm(self.user,
+                                                                    data=user_password_change_data)
         self.assertTrue(user_password_change_form.is_valid())
 
     def test_UserPasswordChangeForm_clean_old_password(self):
         user_password_change_data = {'old_password': 'glass_onion', 'new_password1': 'pass2', 'new_password2': 'pass2'}
-        user_password_change_form = tethys_portal.forms.UserPasswordChangeForm(self.user,
-                                                                               data=user_password_change_data)
+        user_password_change_form = tp_forms.UserPasswordChangeForm(self.user,
+                                                                    data=user_password_change_data)
 
         self.assertTrue(user_password_change_form.is_valid())
 
@@ -217,8 +217,8 @@ class TethysPortalFormsTests(TestCase):
 
     def test_UserPasswordChangeForm_clean_old_password_invalid(self):
         user_password_change_data = {'old_password': 'abc123', 'new_password1': 'pass2', 'new_password2': 'pass2'}
-        user_password_change_form = tethys_portal.forms.UserPasswordChangeForm(self.user,
-                                                                               data=user_password_change_data)
+        user_password_change_form = tp_forms.UserPasswordChangeForm(self.user,
+                                                                    data=user_password_change_data)
 
         # is_valid to get cleaned_data
         self.assertFalse(user_password_change_form.is_valid())
@@ -231,8 +231,7 @@ class TethysPortalFormsTests(TestCase):
     @mock.patch('tethys_portal.forms.validate_password')
     def test_UserPasswordChangeForm_clean_new_password2(self, mock_vp):
         user_password_change_data = {'old_password': 'glass_onion', 'new_password1': 'pass2', 'new_password2': 'pass2'}
-        user_password_change_form = tethys_portal.forms.UserPasswordChangeForm(self.user,
-                                                                               data=user_password_change_data)
+        user_password_change_form = tp_forms.UserPasswordChangeForm(self.user, data=user_password_change_data)
 
         self.assertTrue(user_password_change_form.is_valid())
 
@@ -243,8 +242,7 @@ class TethysPortalFormsTests(TestCase):
 
     def test_UserPasswordChangeForm_clean_new_password2_diff(self):
         user_password_change_data = {'old_password': 'glass_onion', 'new_password1': 'pass1', 'new_password2': 'pass2'}
-        user_password_change_form = tethys_portal.forms.UserPasswordChangeForm(self.user,
-                                                                               data=user_password_change_data)
+        user_password_change_form = tp_forms.UserPasswordChangeForm(self.user, data=user_password_change_data)
 
         # run is_valid to get cleaned_data
         self.assertFalse(user_password_change_form.is_valid())
@@ -261,8 +259,8 @@ class TethysPortalFormsTests(TestCase):
 
         # Update new password
         user_password_change_data = {'old_password': 'glass_onion', 'new_password1': 'pass2', 'new_password2': 'pass2'}
-        user_password_change_form = tethys_portal.forms.UserPasswordChangeForm(self.user,
-                                                                               data=user_password_change_data)
+        user_password_change_form = tp_forms.UserPasswordChangeForm(self.user,
+                                                                    data=user_password_change_data)
 
         # run is_valid to get cleaned_data attributes.
         self.assertTrue(user_password_change_form.is_valid())
@@ -276,3 +274,42 @@ class TethysPortalFormsTests(TestCase):
         # Check result
         self.assertIsInstance(ret_new, User)
         self.assertNotEqual(old_pass, new_pass)
+
+    # SsoTenantForm
+    def test_SsoTenantForm_remember(self):
+        data = {
+            'remember': 'on',
+            'tenant': 'GitHub'
+        }
+
+        form = tp_forms.SsoTenantForm(data)
+
+        self.assertTrue(form.is_valid())
+
+    def test_SsoTenantForm_no_rememeber(self):
+        data = {
+            'tenant': 'Git-Hub_123 Tenant'
+        }
+
+        form = tp_forms.SsoTenantForm(data)
+
+        self.assertTrue(form.is_valid())
+
+    def test_SsoTenantForm_tenant_invalid_chars(self):
+        data = {
+            'remember': 'on',
+            'tenant': 'Git*^$@#%)Hub'
+        }
+
+        form = tp_forms.SsoTenantForm(data)
+
+        self.assertFalse(form.is_valid())
+
+    def test_SsoTenantForm_no_tenant(self):
+        data = {
+            'remember': 'on',
+        }
+
+        form = tp_forms.SsoTenantForm(data)
+
+        self.assertFalse(form.is_valid())

--- a/tests/unit_tests/test_tethys_portal/test_urls.py
+++ b/tests/unit_tests/test_tethys_portal/test_urls.py
@@ -30,6 +30,13 @@ class TestUrls(TethysTestCase):
         self.assertEqual('register', resolver.func.__name__)
         self.assertEqual('tethys_portal.views.accounts', resolver.func.__module__)
 
+    def test_account_urls_accounts_tenant(self):
+        url = reverse('accounts:sso_tenant')
+        resolver = resolve(url)
+        self.assertEqual('/accounts/tenant/', url)
+        self.assertEqual('sso_tenant', resolver.func.__name__)
+        self.assertEqual('tethys_portal.views.accounts', resolver.func.__module__)
+
     def test_account_urls_accounts_password_reset(self):
         url = reverse('accounts:password_reset')
         resolver = resolve(url)

--- a/tests/unit_tests/test_tethys_portal/test_views/test_accounts.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_accounts.py
@@ -1,11 +1,14 @@
 import unittest
 from unittest import mock
+
+from django.http import HttpResponseBadRequest
 from django.test import override_settings
 
 # Fixes the Cache-Control error in tests. Must appear before view imports.
 mock.patch('django.views.decorators.cache.never_cache', lambda x: x).start()
 
-from tethys_portal.views.accounts import login_view, register, logout_view, reset_confirm, reset  # noqa: E402
+from tethys_portal.views.accounts import login_view, register, logout_view, reset_confirm, reset, \
+    sso_tenant  # noqa: E402
 
 
 class TethysPortalViewsAccountsTest(unittest.TestCase):
@@ -593,3 +596,53 @@ class TethysPortalViewsAccountsTest(unittest.TestCase):
                                         email_template_name='tethys_portal/accounts/password_reset/reset_email.html',
                                         subject_template_name='tethys_portal/accounts/password_reset/reset_subject.txt',
                                         success_url='accounts:login')
+
+    @override_settings(SSO_TENANT_ALIAS='foo bar')
+    @mock.patch('tethys_portal.views.accounts.SsoTenantForm')
+    @mock.patch('tethys_portal.views.accounts.render')
+    def test_sso_tenant_get(self, mock_render, mock_tenant_form):
+        mock_request = mock.MagicMock(method='GET', POST=dict())  # GET request
+
+        ret = sso_tenant(mock_request)
+
+        mock_tenant_form.assert_called()
+
+        mock_render.assert_called_with(
+            mock_request,
+            'tethys_portal/accounts/sso_tenant.html',
+            {
+                'form': mock_tenant_form(),
+                'form_title': 'Foo Bar',
+                'page_title': 'Foo Bar'
+            }
+        )
+        self.assertEqual(mock_render(), ret)
+
+    @override_settings(SSO_TENANT_ALIAS='foo bar')
+    @mock.patch('tethys_portal.views.accounts.SsoTenantForm')
+    def test_sso_tenant_view_post_no_submit(self, mock_tenant_form):
+        mock_request = mock.MagicMock(method='POST', POST=dict())  # Empty POST dict
+
+        ret = sso_tenant(mock_request)
+
+        mock_tenant_form.assert_not_called()
+
+        self.assertIsInstance(ret, HttpResponseBadRequest)
+
+    @override_settings(SSO_TENANT_ALIAS='foo bar')
+    @mock.patch('tethys_portal.views.accounts.SsoTenantForm')
+    @mock.patch('tethys_portal.views.accounts.render')
+    def test_sso_tenant_view_post_valid(self, mock_render, mock_tenant_form):
+        post_params = {
+            'sso-tenant-submit': 'submit',
+            'tenant': 'GitHub',
+            'remember': False
+        }
+        mock_request = mock.MagicMock(method='POST', POST=post_params)  # valid POST request
+
+        ret = sso_tenant(mock_request)
+
+        # Make sure form is bound to POST data
+        mock_tenant_form.assert_called_with(mock_request.POST)
+
+        self.assertEqual(mock_render(), ret)

--- a/tethys_portal/forms.py
+++ b/tethys_portal/forms.py
@@ -299,6 +299,6 @@ class SsoTenantForm(forms.Form):
     )
 
     remember = forms.BooleanField(
-        label='Remember my organization',
+        label='Remember for next time',
         required=False,
     )

--- a/tethys_portal/forms.py
+++ b/tethys_portal/forms.py
@@ -279,3 +279,26 @@ class UserPasswordChangeForm(forms.Form):
         if commit:
             self.user.save()
         return self.user
+
+
+class SsoTenantForm(forms.Form):
+    tenant = forms.RegexField(
+        label='',
+        max_length=30,
+        required=True,
+        regex=r'^[\w\s_-]+$',
+        error_messages={
+            'invalid': "This field may contain only letters, numbers, spaces, and -/_ characters."
+        },
+        widget=forms.TextInput(
+            attrs={
+                'placeholder': 'Tenant',
+                'autofocus': 'autofocus'
+            }
+        )
+    )
+
+    remember = forms.BooleanField(
+        label='Remember my organization',
+        required=False,
+    )

--- a/tethys_portal/static/tethys_portal/css/sso_tenant.css
+++ b/tethys_portal/static/tethys_portal/css/sso_tenant.css
@@ -1,0 +1,4 @@
+/* Remember checkbox hidden by default */
+label[for="id_remember"] {
+  display: none;
+}

--- a/tethys_portal/static/tethys_portal/js/sso_tenant.js
+++ b/tethys_portal/static/tethys_portal/js/sso_tenant.js
@@ -1,0 +1,37 @@
+$(function() {
+  if (window.localStorage) {
+    // Show the hidden remember checkbox only if local storage is supported
+    $('label[for="id_remember"]').css('display', 'block');
+
+    // Check local storage for saved data
+    let remember = localStorage.getItem('remember');
+    let tenant = localStorage.getItem('tenant');
+
+    // Set remember field with saved value
+    if (remember != null) {
+      if (remember == 'true') {
+        $('#id_remember').prop('checked', true);
+      } else {
+        $('#id_remember').prop('checked', false);
+      }
+    }
+
+    // Set tenant field with saved value
+    if (tenant != null) {
+      $('#id_tenant').val(tenant);
+    }
+    // Bind to form submit
+    $('#sso-tenant-form').on('submit', function(evt) {
+      if ($('#id_remember').is(":checked")) {
+        // Save form data
+        let tenant = $('#id_tenant').val();
+        localStorage.setItem('remember', 'true');
+        localStorage.setItem('tenant', tenant);
+      } else {
+        // Clear saved form data
+        localStorage.removeItem('remember');
+        localStorage.removeItem('tenant');
+      }
+    });
+  }
+});

--- a/tethys_portal/templates/tethys_portal/accounts/sso_tenant.html
+++ b/tethys_portal/templates/tethys_portal/accounts/sso_tenant.html
@@ -1,0 +1,42 @@
+{% extends "page.html" %}
+
+{% load bootstrap3 static %}
+
+{% block title %}- {{ page_title }}{% endblock %}
+
+{% block styles %}
+  {{ block.super }}
+  <style>
+    body {
+      background: {{ site_globals.background_color|default:'#ffffff' }};
+    }
+  </style>
+  <link rel="stylesheet" href="{% static 'tethys_portal/css/sso_tenant.css' %}">
+{% endblock %}
+
+{% block scripts %}
+  {{ block.super }}
+  <script type="text/javascript" src="{% static 'tethys_portal/js/sso_tenant.js' %}"></script>
+{% endblock %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-md-4 col-md-offset-4">
+      <div class="account-form-wrapper">
+        <div class="account-form-header">
+          <h1>{{ form_title }}</h1>
+        </div>
+        <div class="account-form-body">
+          <form id="sso-tenant-form" role="form" method="post">
+            {% csrf_token %}
+            {% bootstrap_form form %}
+            <button type="submit" id="sso-tenant-submit" class="btn btn-default" name="sso-tenant-submit">Next</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block terms-of-service-override %}
+{% endblock %}

--- a/tethys_portal/urls.py
+++ b/tethys_portal/urls.py
@@ -42,6 +42,7 @@ account_urls = [
     url(r'^login/$', tethys_portal_accounts.login_view, name='login'),
     url(r'^logout/$', tethys_portal_accounts.logout_view, name='logout'),
     url(r'^register/$', tethys_portal_accounts.register, name='register'),
+    url(r'^tenant/$', tethys_portal_accounts.sso_tenant, name='sso_tenant'),
     url(r'^password/reset/$', never_cache(PasswordResetView.as_view(
         success_url=reverse_lazy('accounts:password_reset_done'))
     ), name='password_reset'),

--- a/tethys_portal/views/accounts.py
+++ b/tethys_portal/views/accounts.py
@@ -8,6 +8,7 @@
 ********************************************************************************
 """
 from django.conf import settings
+from django.http import HttpResponseBadRequest
 from django.urls import reverse
 from django.shortcuts import render, redirect
 from django.contrib.auth import authenticate, login, logout
@@ -176,25 +177,24 @@ def sso_tenant(request):
     """
     Handle tenant page request.
     """
-    # Only allow users to access this page if they are not logged in
-    if not request.user.is_anonymous:
-        return redirect('user:profile', username=request.user.username)
-
     # Get SSO_TENANT_ALIAS setting
     tenant_alias = getattr(settings, 'SSO_TENANT_ALIAS', 'Tenant').title()
 
     # Handle form
-    if request.method == 'POST' and 'sso-tenant-submit' in request.POST:
-        # Create form bound to request data
-        form = SsoTenantForm(request.POST)
+    if request.method == 'POST':
+        if 'sso-tenant-submit' not in request.POST:
+            return HttpResponseBadRequest()
+        else:
+            # Create form bound to request data
+            form = SsoTenantForm(request.POST)
 
-        # Validate the form
-        if form.is_valid():
-            cleaned_tenant = form.cleaned_data.get('tenant')
-            normalized_tenant = cleaned_tenant.lower()
-            print(f'"{cleaned_tenant}", "{normalized_tenant}"')
-            # TODO: validate that the normalized_tenant given is a valid tenant in settings
-            # TODO: redirect back to the SSO pipeline with correct Tenant
+            # Validate the form
+            if form.is_valid():
+                cleaned_tenant = form.cleaned_data.get('tenant')
+                normalized_tenant = cleaned_tenant.lower()
+                print(f'"{cleaned_tenant}", "{normalized_tenant}"')
+                # TODO: validate that the normalized_tenant given is a valid tenant in settings
+                # TODO: redirect back to the SSO pipeline with correct Tenant
     else:
         # Create new empty form
         form = SsoTenantForm()

--- a/tethys_portal/views/accounts.py
+++ b/tethys_portal/views/accounts.py
@@ -15,7 +15,7 @@ from django.contrib.auth.views import PasswordResetView, PasswordResetConfirmVie
 from django.contrib import messages
 from django.views.decorators.cache import never_cache
 from mfa.helpers import has_mfa
-from tethys_portal.forms import LoginForm, RegisterForm
+from tethys_portal.forms import LoginForm, RegisterForm, SsoTenantForm
 from tethys_portal.utilities import log_user_in
 
 
@@ -169,3 +169,43 @@ def reset(request):
         subject_template_name='tethys_portal/accounts/password_reset/reset_subject.txt',
         success_url=reverse('accounts:login')
     )
+
+
+@never_cache
+def sso_tenant(request):
+    """
+    Handle tenant page request.
+    """
+    # Only allow users to access this page if they are not logged in
+    if not request.user.is_anonymous:
+        return redirect('user:profile', username=request.user.username)
+
+    # Get SSO_TENANT_ALIAS setting
+    tenant_alias = getattr(settings, 'SSO_TENANT_ALIAS', 'Tenant').title()
+
+    # Handle form
+    if request.method == 'POST' and 'sso-tenant-submit' in request.POST:
+        # Create form bound to request data
+        form = SsoTenantForm(request.POST)
+
+        # Validate the form
+        if form.is_valid():
+            cleaned_tenant = form.cleaned_data.get('tenant')
+            normalized_tenant = cleaned_tenant.lower()
+            print(f'"{cleaned_tenant}", "{normalized_tenant}"')
+            # TODO: validate that the normalized_tenant given is a valid tenant in settings
+            # TODO: redirect back to the SSO pipeline with correct Tenant
+    else:
+        # Create new empty form
+        form = SsoTenantForm()
+
+    # Set placeholder for tenant text input to be same as tenant_alias
+    form.fields['tenant'].widget.attrs['placeholder'] = tenant_alias
+
+    context = {
+        'form': form,
+        'form_title': tenant_alias,
+        'page_title': tenant_alias
+    }
+
+    return render(request, 'tethys_portal/accounts/sso_tenant.html', context)


### PR DESCRIPTION
Adds a new view to Tethys Portal that will eventually be used in an alternative SSO pipeline for services that allow multiple tenants (e.g. onelogin and okta).

* The "Remember my tenant" feature uses local storage in the browser to save the tenant name if the user checks the box.
* The "remember" checkbox will only be shown if local storage is supported in the browser.
* The "Tenant" terminology can be changed using the `SSO_TENANT_ALIAS` setting (e.g.: Organization, Company)

![image](https://user-images.githubusercontent.com/5123221/101541197-54f54000-395e-11eb-88e5-459dcd376f26.png)

