### PR TITLE
Multi-Tenant Pipeline

### DIFF
--- a/docs/tethys_portal/configuration.rst
+++ b/docs/tethys_portal/configuration.rst
@@ -123,6 +123,7 @@ The following is a list of keys that can be added to the :file:`portal_config.ym
   * **OAUTH_CONFIG**:
 
     * **SSO_TENANT_ALIAS**: Alias to use for "Tenant" on the /accounts/tenant/ page. This page is only needed when using Multi-Tenant SSO features. Defaults to "Tenant".
+    * **SSO_TENANT_REGEX**: A regular expression defining the characters allowed in the Tenant field on the /accounts/tenant/ page. This page is only needed when using Multi-Tenant SSO features. Defaults to "^[\w\s_-]+$".
     * **SOCIAL_AUTH_AZUREAD_OAUTH2_KEY**: Key for authenticating with Azure Active Directory using their OAuth2 service. See :ref:`social_auth_azuread` SSO Setup.
     * **SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET**: Secret for authenticating with Azure Active Directory using their OAuth2 service. See :ref:`social_auth_azuread` SSO Setup.
     * **SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY**: Key for authenticating with Azure Active Directory against a single Tenant/Active Directory using their OAuth2 service. See :ref:`social_auth_azuread` SSO Setup.

--- a/tests/unit_tests/test_tethys_portal/test_forms.py
+++ b/tests/unit_tests/test_tethys_portal/test_forms.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 from captcha.models import CaptchaStore
 import tethys_portal.forms as tp_forms
 from django.contrib.auth.models import User
+from django.test import override_settings
 from django import forms
 from unittest import mock
 
@@ -313,3 +314,28 @@ class TethysPortalFormsTests(TestCase):
         form = tp_forms.SsoTenantForm(data)
 
         self.assertFalse(form.is_valid())
+
+    @override_settings(SSO_TENANT_REGEX=r'^[\w\s^$_-]+$')
+    def test_SSoTenantForm_custom_regex(self):
+        reload(tp_forms)
+        data = {
+            'remember': 'on',
+            'tenant': 'Git$^Hub'
+        }
+
+        form = tp_forms.SsoTenantForm(data)
+
+        self.assertTrue(form.is_valid())
+
+    @override_settings(SSO_TENANT_ALIAS='comPany')
+    def test_SsoTenantForm_tenant_alias(self):
+        reload(tp_forms)
+        data = {
+            'remember': 'on',
+            'tenant': 'GitHub'
+        }
+
+        form = tp_forms.SsoTenantForm(data)
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual('Company', form.fields['tenant'].widget.attrs['placeholder'])

--- a/tests/unit_tests/test_tethys_portal/test_urls.py
+++ b/tests/unit_tests/test_tethys_portal/test_urls.py
@@ -30,13 +30,6 @@ class TestUrls(TethysTestCase):
         self.assertEqual('register', resolver.func.__name__)
         self.assertEqual('tethys_portal.views.accounts', resolver.func.__module__)
 
-    def test_account_urls_accounts_tenant(self):
-        url = reverse('accounts:sso_tenant')
-        resolver = resolve(url)
-        self.assertEqual('/accounts/tenant/', url)
-        self.assertEqual('sso_tenant', resolver.func.__name__)
-        self.assertEqual('tethys_portal.views.accounts', resolver.func.__module__)
-
     def test_account_urls_accounts_password_reset(self):
         url = reverse('accounts:password_reset')
         resolver = resolve(url)
@@ -92,6 +85,13 @@ class TestUrls(TethysTestCase):
         self.assertEqual('/oauth2/disconnect/foo/123/', url)
         self.assertEqual('disconnect', resolver.func.__name__)
         self.assertEqual('social_django.views', resolver.func.__module__)
+
+    def test_oauth2_urls_tenant(self):
+        url = reverse('social:tenant', kwargs={'backend': 'foo'})
+        resolver = resolve(url)
+        self.assertEqual('/oauth2/tenant/foo/', url)
+        self.assertEqual('tenant', resolver.func.__name__)
+        self.assertEqual('tethys_portal.views.psa', resolver.func.__module__)
 
     def test_user_urls_profile(self):
         url = reverse('user:profile', kwargs={'username': 'foo'})

--- a/tests/unit_tests/test_tethys_portal/test_urls.py
+++ b/tests/unit_tests/test_tethys_portal/test_urls.py
@@ -70,7 +70,7 @@ class TestUrls(TethysTestCase):
         resolver = resolve(url)
         self.assertEqual('/oauth2/complete/foo/', url)
         self.assertEqual('complete', resolver.func.__name__)
-        self.assertEqual('social_django.views', resolver.func.__module__)
+        self.assertEqual('tethys_portal.views.psa', resolver.func.__module__)
 
     def test_oauth2_urls_disconnect(self):
         url = reverse('social:disconnect', kwargs={'backend': 'foo'})

--- a/tests/unit_tests/test_tethys_portal/test_urls.py
+++ b/tests/unit_tests/test_tethys_portal/test_urls.py
@@ -65,6 +65,34 @@ class TestUrls(TethysTestCase):
         self.assertEqual('PasswordResetCompleteView', resolver.func.__name__)
         self.assertEqual('django.contrib.auth.views', resolver.func.__module__)
 
+    def test_oauth2_urls_login(self):
+        url = reverse('social:begin', kwargs={'backend': 'foo'})
+        resolver = resolve(url)
+        self.assertEqual('/oauth2/login/foo/', url)
+        self.assertEqual('auth', resolver.func.__name__)
+        self.assertEqual('tethys_portal.views.psa', resolver.func.__module__)
+
+    def test_oauth2_urls_complete(self):
+        url = reverse('social:complete', kwargs={'backend': 'foo'})
+        resolver = resolve(url)
+        self.assertEqual('/oauth2/complete/foo/', url)
+        self.assertEqual('complete', resolver.func.__name__)
+        self.assertEqual('social_django.views', resolver.func.__module__)
+
+    def test_oauth2_urls_disconnect(self):
+        url = reverse('social:disconnect', kwargs={'backend': 'foo'})
+        resolver = resolve(url)
+        self.assertEqual('/oauth2/disconnect/foo/', url)
+        self.assertEqual('disconnect', resolver.func.__name__)
+        self.assertEqual('social_django.views', resolver.func.__module__)
+
+    def test_oauth2_urls_disconnect_individual(self):
+        url = reverse('social:disconnect_individual', kwargs={'backend': 'foo', 'association_id': '123'})
+        resolver = resolve(url)
+        self.assertEqual('/oauth2/disconnect/foo/123/', url)
+        self.assertEqual('disconnect', resolver.func.__name__)
+        self.assertEqual('social_django.views', resolver.func.__module__)
+
     def test_user_urls_profile(self):
         url = reverse('user:profile', kwargs={'username': 'foo'})
         resolver = resolve(url)

--- a/tests/unit_tests/test_tethys_portal/test_views/mock_decorator.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/mock_decorator.py
@@ -1,0 +1,10 @@
+from functools import wraps
+
+
+def mock_decorator(*_, **__):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/tests/unit_tests/test_tethys_portal/test_views/test_psa.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_psa.py
@@ -4,6 +4,7 @@ from unittest import mock
 from django.http import HttpResponseBadRequest
 from django.test import override_settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.core.exceptions import ImproperlyConfigured
 from social_core.backends.base import BaseAuth
 
 from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
@@ -69,9 +70,9 @@ class TethysPortalViewsAccountsTest(unittest.TestCase):
     def test_tenant_view_post_no_submit(self, mock_tenant_form):
         mock_backend = mock.MagicMock(spec=MultiTenantMixin)
         mock_request = mock.MagicMock(method='POST', POST=dict(), backend=mock_backend)  # Empty POST dict
-        backend = 'foo'
+        url_backend = 'foo'
 
-        ret = tenant(mock_request, backend)
+        ret = tenant(mock_request, url_backend)
 
         mock_tenant_form.assert_not_called()
 
@@ -90,9 +91,9 @@ class TethysPortalViewsAccountsTest(unittest.TestCase):
             'remember': False
         }
         mock_request = mock.MagicMock(method='POST', POST=post_params, backend=mock_backend)  # valid POST request
-        backend = 'foo'
+        url_backend = 'foo'
 
-        ret = tenant(mock_request, backend)
+        ret = tenant(mock_request, url_backend)
 
         # Make sure form is bound to POST data
         mock_tenant_form.assert_called_with(mock_request.POST)
@@ -100,3 +101,67 @@ class TethysPortalViewsAccountsTest(unittest.TestCase):
         mock_do_auth.assert_called_with(mock_backend, redirect_name=REDIRECT_FIELD_NAME)
         self.assertEqual('GitHub', mock_backend.tenant)
         self.assertEqual(mock_do_auth(), ret)
+
+    @override_settings(SSO_TENANT_ALIAS='foo bar')
+    @mock.patch('tethys_portal.views.psa.log')
+    @mock.patch('tethys_portal.views.psa.redirect')
+    @mock.patch('tethys_portal.views.psa.do_auth')
+    @mock.patch('tethys_portal.views.psa.SsoTenantForm', spec=SsoTenantForm)
+    def test_tenant_view_post_improperly_configured(self, mock_tenant_form, mock_do_auth, mock_redirect, mock_log):
+        mock_tenant_form.is_valid = mock.MagicMock(return_value=True)
+        mock_tenant_form().cleaned_data = {'tenant': 'GitHub'}
+        mock_backend = mock.MagicMock(spec=MultiTenantMixin)
+        type(mock_backend).tenant = mock.PropertyMock(side_effect=ImproperlyConfigured('some error message'))
+        post_params = {
+            'sso-tenant-submit': 'submit',
+            'tenant': 'GitHub',
+            'remember': False
+        }
+        mock_request = mock.MagicMock(method='POST', POST=post_params, backend=mock_backend)  # valid POST request
+        url_backend = 'foo'
+
+        ret = tenant(mock_request, url_backend)
+
+        # Make sure form is bound to POST data
+        mock_tenant_form.assert_called_with(mock_request.POST)
+        mock_tenant_form().is_valid.assert_called()
+        mock_do_auth.assert_not_called()
+        mock_log.error.assert_called_with('some error message')
+        mock_redirect.assert_called_with('accounts:login')
+        self.assertEqual(mock_redirect(), ret)
+
+    @override_settings(SSO_TENANT_ALIAS='Thingy')
+    @mock.patch('tethys_portal.views.psa.render')
+    @mock.patch('tethys_portal.views.psa.do_auth')
+    @mock.patch('tethys_portal.views.psa.SsoTenantForm', spec=SsoTenantForm)
+    def test_tenant_view_post_value_error(self, mock_tenant_form, mock_do_auth, mock_render):
+        mock_tenant_form.is_valid = mock.MagicMock(return_value=True)
+        mock_tenant_form().cleaned_data = {'tenant': 'GitHub'}
+        mock_backend = mock.MagicMock(spec=MultiTenantMixin)
+        type(mock_backend).tenant = mock.PropertyMock(side_effect=ValueError)
+        post_params = {
+            'sso-tenant-submit': 'submit',
+            'tenant': 'GitHub',
+            'remember': False
+        }
+        mock_request = mock.MagicMock(method='POST', POST=post_params, backend=mock_backend)  # valid POST request
+        url_backend = 'foo'
+
+        ret = tenant(mock_request, url_backend)
+
+        # Make sure form is bound to POST data
+        mock_tenant_form.assert_called_with(mock_request.POST)
+        mock_tenant_form().is_valid.assert_called()
+        mock_do_auth.assert_not_called()
+        mock_tenant_form().add_error.assert_called_with('tenant', 'Invalid thingy provided.')
+        mock_render.assert_called_with(
+            mock_request,
+            'tethys_portal/accounts/sso_tenant.html',
+            {
+                'form': mock_tenant_form(),
+                'form_title': 'Thingy',
+                'page_title': 'Thingy',
+                'backend': url_backend
+            }
+        )
+        self.assertEqual(mock_render(), ret)

--- a/tests/unit_tests/test_tethys_portal/test_views/test_psa.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_psa.py
@@ -3,7 +3,11 @@ from unittest import mock
 
 from django.http import HttpResponseBadRequest
 from django.test import override_settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from social_core.backends.base import BaseAuth
 
+from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
+from tethys_portal.forms import SsoTenantForm
 from .mock_decorator import mock_decorator
 
 # Fixes the Cache-Control error in tests. Must appear before view imports.
@@ -22,13 +26,29 @@ class TethysPortalViewsAccountsTest(unittest.TestCase):
         pass
 
     @override_settings(SSO_TENANT_ALIAS='foo bar')
-    @mock.patch('tethys_portal.views.psa.SsoTenantForm')
+    @mock.patch('tethys_portal.views.psa.log')
+    @mock.patch('tethys_portal.views.psa.redirect')
+    def test_tenant_get_backend_not_mtm(self, mock_redirect, mock_log):
+        mock_backend = mock.MagicMock(spec=BaseAuth)  # Not a MultiTenantMixin
+        mock_backend.name = 'other backend'
+        mock_request = mock.MagicMock(method='GET', GET=dict(), backend=mock_backend)  # GET request
+        url_backend = 'foo'
+
+        ret = tenant(mock_request, backend=url_backend)
+
+        mock_log.error.assert_called_with('Backend "other backend" does not support MULTI_TENANT features.')
+        mock_redirect.assert_called_with('accounts:login')
+        self.assertEqual(mock_redirect(), ret)
+
+    @override_settings(SSO_TENANT_ALIAS='foo bar')
+    @mock.patch('tethys_portal.views.psa.SsoTenantForm', spec=SsoTenantForm)
     @mock.patch('tethys_portal.views.psa.render')
     def test_tenant_get(self, mock_render, mock_tenant_form):
-        mock_request = mock.MagicMock(method='GET', POST=dict())  # GET request
-        backend = 'foo'
+        mock_backend = mock.MagicMock(spec=MultiTenantMixin)
+        mock_request = mock.MagicMock(method='GET', GET=dict(), backend=mock_backend)  # GET request
+        url_backend = 'foo'
 
-        ret = tenant(mock_request, backend=backend)
+        ret = tenant(mock_request, backend=url_backend)
 
         mock_tenant_form.assert_called()
 
@@ -38,15 +58,17 @@ class TethysPortalViewsAccountsTest(unittest.TestCase):
             {
                 'form': mock_tenant_form(),
                 'form_title': 'Foo Bar',
-                'page_title': 'Foo Bar'
+                'page_title': 'Foo Bar',
+                'backend': url_backend
             }
         )
         self.assertEqual(mock_render(), ret)
 
     @override_settings(SSO_TENANT_ALIAS='foo bar')
-    @mock.patch('tethys_portal.forms.SsoTenantForm')
+    @mock.patch('tethys_portal.forms.SsoTenantForm', spec=SsoTenantForm)
     def test_tenant_view_post_no_submit(self, mock_tenant_form):
-        mock_request = mock.MagicMock(method='POST', POST=dict())  # Empty POST dict
+        mock_backend = mock.MagicMock(spec=MultiTenantMixin)
+        mock_request = mock.MagicMock(method='POST', POST=dict(), backend=mock_backend)  # Empty POST dict
         backend = 'foo'
 
         ret = tenant(mock_request, backend)
@@ -56,20 +78,25 @@ class TethysPortalViewsAccountsTest(unittest.TestCase):
         self.assertIsInstance(ret, HttpResponseBadRequest)
 
     @override_settings(SSO_TENANT_ALIAS='foo bar')
-    @mock.patch('tethys_portal.views.psa.SsoTenantForm')
-    @mock.patch('tethys_portal.views.psa.render')
-    def test_tenant_view_post_valid(self, mock_render, mock_tenant_form):
+    @mock.patch('tethys_portal.views.psa.do_auth')
+    @mock.patch('tethys_portal.views.psa.SsoTenantForm', spec=SsoTenantForm)
+    def test_tenant_view_post_valid(self, mock_tenant_form, mock_do_auth):
+        mock_tenant_form.is_valid = mock.MagicMock(return_value=True)
+        mock_tenant_form().cleaned_data = {'tenant': 'GitHub'}
+        mock_backend = mock.MagicMock(spec=MultiTenantMixin)
         post_params = {
             'sso-tenant-submit': 'submit',
             'tenant': 'GitHub',
             'remember': False
         }
-        mock_request = mock.MagicMock(method='POST', POST=post_params)  # valid POST request
+        mock_request = mock.MagicMock(method='POST', POST=post_params, backend=mock_backend)  # valid POST request
         backend = 'foo'
 
         ret = tenant(mock_request, backend)
 
         # Make sure form is bound to POST data
         mock_tenant_form.assert_called_with(mock_request.POST)
-
-        self.assertEqual(mock_render(), ret)
+        mock_tenant_form().is_valid.assert_called()
+        mock_do_auth.assert_called_with(mock_backend, redirect_name=REDIRECT_FIELD_NAME)
+        self.assertEqual('GitHub', mock_backend.tenant)
+        self.assertEqual(mock_do_auth(), ret)

--- a/tests/unit_tests/test_tethys_portal/test_views/test_psa.py
+++ b/tests/unit_tests/test_tethys_portal/test_views/test_psa.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest import mock
+
+from django.http import HttpResponseBadRequest
+from django.test import override_settings
+
+from .mock_decorator import mock_decorator
+
+# Fixes the Cache-Control error in tests. Must appear before view imports.
+mock.patch('django.views.decorators.cache.never_cache', lambda x: x).start()
+mock.patch('social_django.utils.psa', side_effect=mock_decorator).start()
+
+from tethys_portal.views.psa import tenant  # noqa: E402
+
+
+class TethysPortalViewsAccountsTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    @override_settings(SSO_TENANT_ALIAS='foo bar')
+    @mock.patch('tethys_portal.views.psa.SsoTenantForm')
+    @mock.patch('tethys_portal.views.psa.render')
+    def test_tenant_get(self, mock_render, mock_tenant_form):
+        mock_request = mock.MagicMock(method='GET', POST=dict())  # GET request
+        backend = 'foo'
+
+        ret = tenant(mock_request, backend=backend)
+
+        mock_tenant_form.assert_called()
+
+        mock_render.assert_called_with(
+            mock_request,
+            'tethys_portal/accounts/sso_tenant.html',
+            {
+                'form': mock_tenant_form(),
+                'form_title': 'Foo Bar',
+                'page_title': 'Foo Bar'
+            }
+        )
+        self.assertEqual(mock_render(), ret)
+
+    @override_settings(SSO_TENANT_ALIAS='foo bar')
+    @mock.patch('tethys_portal.forms.SsoTenantForm')
+    def test_tenant_view_post_no_submit(self, mock_tenant_form):
+        mock_request = mock.MagicMock(method='POST', POST=dict())  # Empty POST dict
+        backend = 'foo'
+
+        ret = tenant(mock_request, backend)
+
+        mock_tenant_form.assert_not_called()
+
+        self.assertIsInstance(ret, HttpResponseBadRequest)
+
+    @override_settings(SSO_TENANT_ALIAS='foo bar')
+    @mock.patch('tethys_portal.views.psa.SsoTenantForm')
+    @mock.patch('tethys_portal.views.psa.render')
+    def test_tenant_view_post_valid(self, mock_render, mock_tenant_form):
+        post_params = {
+            'sso-tenant-submit': 'submit',
+            'tenant': 'GitHub',
+            'remember': False
+        }
+        mock_request = mock.MagicMock(method='POST', POST=post_params)  # valid POST request
+        backend = 'foo'
+
+        ret = tenant(mock_request, backend)
+
+        # Make sure form is bound to POST data
+        mock_tenant_form.assert_called_with(mock_request.POST)
+
+        self.assertEqual(mock_render(), ret)

--- a/tests/unit_tests/test_tethys_services/test_backends/test_adfs.py
+++ b/tests/unit_tests/test_tethys_services/test_backends/test_adfs.py
@@ -1,5 +1,6 @@
 from django import test
 from tethys_services.backends.adfs import ADFSOpenIdConnect
+from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
 
 
 @test.override_settings(
@@ -14,6 +15,10 @@ class ADFSOpenIdConnectBackendTest(test.SimpleTestCase):
 
     def tearDown(self):
         pass
+
+    def test_is_mtm(self):
+        inst = ADFSOpenIdConnect()
+        self.assertIsInstance(inst, MultiTenantMixin)
 
     def test_oidc_endpoint(self):
         inst = ADFSOpenIdConnect()

--- a/tests/unit_tests/test_tethys_services/test_backends/test_adfs.py
+++ b/tests/unit_tests/test_tethys_services/test_backends/test_adfs.py
@@ -1,5 +1,5 @@
 from django import test
-from tethys_services.backends.adfs import ADFSOpenIdConnect
+from tethys_services.backends.adfs import ADFSOpenIdConnect, ADFSOpenIdConnectMultiTenant
 from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
 
 
@@ -15,10 +15,6 @@ class ADFSOpenIdConnectBackendTest(test.SimpleTestCase):
 
     def tearDown(self):
         pass
-
-    def test_is_mtm(self):
-        inst = ADFSOpenIdConnect()
-        self.assertIsInstance(inst, MultiTenantMixin)
 
     def test_oidc_endpoint(self):
         inst = ADFSOpenIdConnect()
@@ -51,3 +47,16 @@ class ADFSOpenIdConnectBackendTest(test.SimpleTestCase):
         ret = inst.OIDC_ENDPOINT
 
         self.assertEqual('https://adfs.my-org.mok/adfs', ret)
+
+
+class ADFSOpenIdConnectMultiTenantBackendTest(test.SimpleTestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_is_mtm(self):
+        inst = ADFSOpenIdConnectMultiTenant()
+        self.assertIsInstance(inst, MultiTenantMixin)

--- a/tests/unit_tests/test_tethys_services/test_backends/test_azuread.py
+++ b/tests/unit_tests/test_tethys_services/test_backends/test_azuread.py
@@ -1,0 +1,29 @@
+from django import test
+from tethys_services.backends.azuread import AzureADB2COAuth2MultiTenant, AzureADTenantOAuth2MultiTenant
+from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
+
+
+class AzureADB2COAuth2MultiTenantBackendTest(test.SimpleTestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_is_mtm(self):
+        inst = AzureADB2COAuth2MultiTenant()
+        self.assertIsInstance(inst, MultiTenantMixin)
+
+
+class AzureADTenantOAuth2MultiTenantBackendTest(test.SimpleTestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_is_mtm(self):
+        inst = AzureADTenantOAuth2MultiTenant()
+        self.assertIsInstance(inst, MultiTenantMixin)

--- a/tests/unit_tests/test_tethys_services/test_backends/test_multi_tenant_mixin.py
+++ b/tests/unit_tests/test_tethys_services/test_backends/test_multi_tenant_mixin.py
@@ -6,11 +6,15 @@ from django.core.exceptions import ImproperlyConfigured
 from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
 
 
-class TestMtmBackend(MultiTenantMixin):
-    name = 'test-mtm'
-    
+class FakeOAuth:
+
     def setting(self, name, default=None):
+        """Provide fake super().setting() method."""
         return 'super-setting-call'
+
+
+class TestMtmBackend(MultiTenantMixin, FakeOAuth):
+    name = 'test-mtm'
 
 
 class MultiTenantMixinTests(test.SimpleTestCase):
@@ -38,7 +42,7 @@ class MultiTenantMixinTests(test.SimpleTestCase):
         ret = self.backend.tenant
 
         self.assertEqual('foo', ret)
-    
+
     def test_tenant_setter_valid(self):
         tenant_in = 'Foo Bar'
         self.backend.setting = mock.MagicMock(return_value=self.multi_tenant_setting)
@@ -46,7 +50,7 @@ class MultiTenantMixinTests(test.SimpleTestCase):
         self.backend.tenant = tenant_in
 
         self.assertEqual('foo bar', self.backend._tenant)
-    
+
     def test_tenant_setter_improperly_configured(self):
         tenant_in = 'Foo Bar'
         self.backend.setting = mock.MagicMock(return_value=None)
@@ -57,7 +61,7 @@ class MultiTenantMixinTests(test.SimpleTestCase):
         self.assertEqual('Backend "test-mtm" not configured for multi-tenant: '
                          'SOCIAL_AUTH_TEST_MTM_MULTI_TENANT setting not found.',
                          str(cm.exception))
-    
+
     def test_tenant_setter_value_error(self):
         tenant_in = 'Foo Bar'
         self.backend.setting = mock.MagicMock(return_value={'some other tenant': {}})
@@ -67,7 +71,7 @@ class MultiTenantMixinTests(test.SimpleTestCase):
 
         self.assertEqual('Tenant "foo bar" not found in SOCIAL_AUTH_TEST_MTM_MULTI_TENANT.',
                          str(cm.exception))
-    
+
     def test_tenant_settings_not_loaded(self):
         self.backend._tenant = 'foo bar'
         self.backend.setting = mock.MagicMock(return_value=self.multi_tenant_setting)
@@ -76,7 +80,7 @@ class MultiTenantMixinTests(test.SimpleTestCase):
 
         self.assertDictEqual(self.foo_bar_settings, ret)
         self.assertDictEqual(self.foo_bar_settings, self.backend._tenant_settings)
-    
+
     def test_tenant_settings_loaded(self):
         self.backend._tenant = 'foo bar'
         self.backend._tenant_settings = self.foo_bar_settings
@@ -87,12 +91,12 @@ class MultiTenantMixinTests(test.SimpleTestCase):
 
         self.assertDictEqual(self.foo_bar_settings, ret)
         mock_multi_tenant_settings.assert_not_called()
-    
+
     def test_tenant_settings_no_tenant(self):
         ret = self.backend.tenant_settings
 
         self.assertIsNone(ret)
-    
+
     def test_tenant_settings_no_mutli_tenant_setting(self):
         self.backend._tenant = 'foo bar'
         self.backend.setting = mock.MagicMock(return_value=None)
@@ -100,7 +104,7 @@ class MultiTenantMixinTests(test.SimpleTestCase):
         ret = self.backend.tenant_settings
 
         self.assertIsNone(ret)
-    
+
     def test_tenant_settings_tenant_not_in_multi_tenant_settings(self):
         self.backend._tenant = 'foo bar'
         self.backend.setting = mock.MagicMock(return_value={'some other tenant': {}})
@@ -113,7 +117,7 @@ class MultiTenantMixinTests(test.SimpleTestCase):
         ret = self.backend.setting('MULTI_TENANT')
 
         self.assertEqual('super-setting-call', ret)
-    
+
     @mock.patch('tethys_services.backends.multi_tenant_mixin.MultiTenantMixin.tenant_settings',
                 new_callable=mock.PropertyMock)
     def test_setting_no_tenant_settings(self, mock_tenant_settings):
@@ -128,7 +132,7 @@ class MultiTenantMixinTests(test.SimpleTestCase):
                 new_callable=mock.PropertyMock)
     def test_setting_not_in_tenant_settings(self, mock_tenant_settings):
         backend = TestMtmBackend()
-        mock_tenant_settings.return_value = self.multi_tenant_setting
+        mock_tenant_settings.return_value = self.foo_bar_settings
 
         ret = backend.setting('FOO')
 
@@ -138,8 +142,8 @@ class MultiTenantMixinTests(test.SimpleTestCase):
                 new_callable=mock.PropertyMock)
     def test_setting_in_tenant_settings(self, mock_tenant_settings):
         backend = TestMtmBackend()
-        mock_tenant_settings.return_value = self.multi_tenant_setting
-
+        mock_tenant_settings.return_value = self.foo_bar_settings
+        self.assertDictEqual(self.foo_bar_settings, backend.tenant_settings)
         ret = backend.setting('KEY')
 
         self.assertEqual(self.test_key, ret)

--- a/tests/unit_tests/test_tethys_services/test_backends/test_multi_tenant_mixin.py
+++ b/tests/unit_tests/test_tethys_services/test_backends/test_multi_tenant_mixin.py
@@ -1,0 +1,145 @@
+from unittest import mock
+
+from django import test
+from django.core.exceptions import ImproperlyConfigured
+
+from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
+
+
+class TestMtmBackend(MultiTenantMixin):
+    name = 'test-mtm'
+    
+    def setting(self, name, default=None):
+        return 'super-setting-call'
+
+
+class MultiTenantMixinTests(test.SimpleTestCase):
+
+    def setUp(self):
+        self.backend = TestMtmBackend()
+        self.test_key = '182f8cb0-b8b2-0138-3936-0647e35409d7171986'
+        self.test_secret = '032f86d0f5f367171fd6270f7f5fa383fa27604fake9c5f1a0a5d5d2b4227ace'
+        self.test_domain = 'https://adfs.my-org.mok'
+        self.foo_bar_settings = {
+            'SOCIAL_AUTH_TEST_MTM_KEY': self.test_key,
+            'SOCIAL_AUTH_TEST_MTM_SECRET': self.test_secret,
+            'SOCIAL_AUTH_TEST_MTM_DOMAIN': self.test_domain
+        }
+        self.multi_tenant_setting = {'foo bar': self.foo_bar_settings}
+
+    def test_tenant_getter_not_set(self):
+        ret = self.backend.tenant
+
+        self.assertIsNone(ret)
+
+    def test_tenant_getter_set(self):
+        self.backend._tenant = 'foo'
+
+        ret = self.backend.tenant
+
+        self.assertEqual('foo', ret)
+    
+    def test_tenant_setter_valid(self):
+        tenant_in = 'Foo Bar'
+        self.backend.setting = mock.MagicMock(return_value=self.multi_tenant_setting)
+
+        self.backend.tenant = tenant_in
+
+        self.assertEqual('foo bar', self.backend._tenant)
+    
+    def test_tenant_setter_improperly_configured(self):
+        tenant_in = 'Foo Bar'
+        self.backend.setting = mock.MagicMock(return_value=None)
+
+        with self.assertRaises(ImproperlyConfigured) as cm:
+            self.backend.tenant = tenant_in
+
+        self.assertEqual('Backend "test-mtm" not configured for multi-tenant: '
+                         'SOCIAL_AUTH_TEST_MTM_MULTI_TENANT setting not found.',
+                         str(cm.exception))
+    
+    def test_tenant_setter_value_error(self):
+        tenant_in = 'Foo Bar'
+        self.backend.setting = mock.MagicMock(return_value={'some other tenant': {}})
+
+        with self.assertRaises(ValueError) as cm:
+            self.backend.tenant = tenant_in
+
+        self.assertEqual('Tenant "foo bar" not found in SOCIAL_AUTH_TEST_MTM_MULTI_TENANT.',
+                         str(cm.exception))
+    
+    def test_tenant_settings_not_loaded(self):
+        self.backend._tenant = 'foo bar'
+        self.backend.setting = mock.MagicMock(return_value=self.multi_tenant_setting)
+
+        ret = self.backend.tenant_settings
+
+        self.assertDictEqual(self.foo_bar_settings, ret)
+        self.assertDictEqual(self.foo_bar_settings, self.backend._tenant_settings)
+    
+    def test_tenant_settings_loaded(self):
+        self.backend._tenant = 'foo bar'
+        self.backend._tenant_settings = self.foo_bar_settings
+        mock_multi_tenant_settings = mock.MagicMock()
+        self.backend.setting = mock_multi_tenant_settings
+
+        ret = self.backend.tenant_settings
+
+        self.assertDictEqual(self.foo_bar_settings, ret)
+        mock_multi_tenant_settings.assert_not_called()
+    
+    def test_tenant_settings_no_tenant(self):
+        ret = self.backend.tenant_settings
+
+        self.assertIsNone(ret)
+    
+    def test_tenant_settings_no_mutli_tenant_setting(self):
+        self.backend._tenant = 'foo bar'
+        self.backend.setting = mock.MagicMock(return_value=None)
+
+        ret = self.backend.tenant_settings
+
+        self.assertIsNone(ret)
+    
+    def test_tenant_settings_tenant_not_in_multi_tenant_settings(self):
+        self.backend._tenant = 'foo bar'
+        self.backend.setting = mock.MagicMock(return_value={'some other tenant': {}})
+
+        ret = self.backend.tenant_settings
+
+        self.assertIsNone(ret)
+
+    def test_setting_name_is_multi_tenant(self):
+        ret = self.backend.setting('MULTI_TENANT')
+
+        self.assertEqual('super-setting-call', ret)
+    
+    @mock.patch('tethys_services.backends.multi_tenant_mixin.MultiTenantMixin.tenant_settings',
+                new_callable=mock.PropertyMock)
+    def test_setting_no_tenant_settings(self, mock_tenant_settings):
+        backend = TestMtmBackend()
+        mock_tenant_settings.return_value = None
+
+        ret = backend.setting('KEY')
+
+        self.assertEqual('super-setting-call', ret)
+
+    @mock.patch('tethys_services.backends.multi_tenant_mixin.MultiTenantMixin.tenant_settings',
+                new_callable=mock.PropertyMock)
+    def test_setting_not_in_tenant_settings(self, mock_tenant_settings):
+        backend = TestMtmBackend()
+        mock_tenant_settings.return_value = self.multi_tenant_setting
+
+        ret = backend.setting('FOO')
+
+        self.assertEqual('super-setting-call', ret)
+
+    @mock.patch('tethys_services.backends.multi_tenant_mixin.MultiTenantMixin.tenant_settings',
+                new_callable=mock.PropertyMock)
+    def test_setting_in_tenant_settings(self, mock_tenant_settings):
+        backend = TestMtmBackend()
+        mock_tenant_settings.return_value = self.multi_tenant_setting
+
+        ret = backend.setting('KEY')
+
+        self.assertEqual(self.test_key, ret)

--- a/tests/unit_tests/test_tethys_services/test_backends/test_okta.py
+++ b/tests/unit_tests/test_tethys_services/test_backends/test_okta.py
@@ -1,0 +1,29 @@
+from django import test
+from tethys_services.backends.okta import OktaOpenIdConnectMultiTenant, OktaOauth2MultiTenant
+from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
+
+
+class OktaOpenIdConnectMultiTenantBackendTest(test.SimpleTestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_is_mtm(self):
+        inst = OktaOpenIdConnectMultiTenant()
+        self.assertIsInstance(inst, MultiTenantMixin)
+
+
+class OktaOauth2MultiTenantBackendTest(test.SimpleTestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_is_mtm(self):
+        inst = OktaOauth2MultiTenant()
+        self.assertIsInstance(inst, MultiTenantMixin)

--- a/tests/unit_tests/test_tethys_services/test_backends/test_onelogin.py
+++ b/tests/unit_tests/test_tethys_services/test_backends/test_onelogin.py
@@ -10,6 +10,7 @@ from jose import jwt
 from jose.utils import base64url_encode
 from django import test
 from tethys_services.backends.onelogin import OneLoginOIDC
+from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
 
 
 client_id = '182f8cb0-b8b2-0138-3936-0647e35409d7174645'
@@ -134,6 +135,10 @@ class OneLoginOIDCBackendTest(test.SimpleTestCase):
         digest_truncated = digest[:(int(len(digest) / 2))]
         at_hash = base64url_encode(digest_truncated).decode()
         return at_hash
+
+    def test_is_mtm(self):
+        inst = OneLoginOIDC()
+        self.assertIsInstance(inst, MultiTenantMixin)
 
     def test_oidc_endpoint(self):
         inst = OneLoginOIDC()

--- a/tests/unit_tests/test_tethys_services/test_backends/test_onelogin.py
+++ b/tests/unit_tests/test_tethys_services/test_backends/test_onelogin.py
@@ -9,7 +9,7 @@ from jose.jwt import JWTError
 from jose import jwt
 from jose.utils import base64url_encode
 from django import test
-from tethys_services.backends.onelogin import OneLoginOIDC
+from tethys_services.backends.onelogin import OneLoginOIDC, OneLoginOIDCMultiTenant
 from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
 
 
@@ -136,10 +136,6 @@ class OneLoginOIDCBackendTest(test.SimpleTestCase):
         at_hash = base64url_encode(digest_truncated).decode()
         return at_hash
 
-    def test_is_mtm(self):
-        inst = OneLoginOIDC()
-        self.assertIsInstance(inst, MultiTenantMixin)
-
     def test_oidc_endpoint(self):
         inst = OneLoginOIDC()
         ret = inst.OIDC_ENDPOINT
@@ -239,3 +235,16 @@ class OneLoginOIDCBackendTest(test.SimpleTestCase):
             inst.validate_and_return_id_token(id_token, access_token)
 
         self.assertEqual(str(cm.exception), 'Token error: Invalid signature')
+
+
+class OneLoginOIDCMultiTenantBackendTest(test.SimpleTestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_is_mtm(self):
+        inst = OneLoginOIDCMultiTenant()
+        self.assertIsInstance(inst, MultiTenantMixin)

--- a/tethys_portal/forms.py
+++ b/tethys_portal/forms.py
@@ -286,13 +286,13 @@ class SsoTenantForm(forms.Form):
         label='',
         max_length=30,
         required=True,
-        regex=r'^[\w\s_-]+$',
+        regex=getattr(settings, 'SSO_TENANT_REGEX', r'^[\w\s_-]+$'),
         error_messages={
-            'invalid': "This field may contain only letters, numbers, spaces, and -/_ characters."
+            'invalid': "Invalid characters provided."
         },
         widget=forms.TextInput(
             attrs={
-                'placeholder': 'Tenant',
+                'placeholder': getattr(settings, 'SSO_TENANT_ALIAS', 'Tenant').title(),
                 'autofocus': 'autofocus'
             }
         )

--- a/tethys_portal/settings.py
+++ b/tethys_portal/settings.py
@@ -311,6 +311,7 @@ SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'first_name', 'email']
 SOCIAL_AUTH_SLUGIFY_USERNAMES = True
 SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/apps/'
 SOCIAL_AUTH_LOGIN_ERROR_URL = '/accounts/login/'
+SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ['tenant']
 
 # OAuth Providers
 OAUTH_CONFIG = portal_config_settings.pop('OAUTH_CONFIG', {})

--- a/tethys_portal/static/tethys_portal/js/sso_tenant.js
+++ b/tethys_portal/static/tethys_portal/js/sso_tenant.js
@@ -4,8 +4,14 @@ $(function() {
     $('label[for="id_remember"]').css('display', 'block');
 
     // Check local storage for saved data
-    let remember = localStorage.getItem('remember');
-    let tenant = localStorage.getItem('tenant');
+    let backend = $('#backend').val();
+    let remember_key = `${backend}-remember`;
+    let tenant_key = `${backend}-tenant`;
+    let remember = localStorage.getItem(remember_key);
+    let tenant = localStorage.getItem(tenant_key);
+    console.log(backend);
+    console.log(remember_key);
+    console.log(tenant_key);
 
     // Set remember field with saved value
     if (remember != null) {
@@ -25,12 +31,12 @@ $(function() {
       if ($('#id_remember').is(":checked")) {
         // Save form data
         let tenant = $('#id_tenant').val();
-        localStorage.setItem('remember', 'true');
-        localStorage.setItem('tenant', tenant);
+        localStorage.setItem(remember_key, 'true');
+        localStorage.setItem(tenant_key, tenant);
       } else {
         // Clear saved form data
-        localStorage.removeItem('remember');
-        localStorage.removeItem('tenant');
+        localStorage.removeItem(remember_key);
+        localStorage.removeItem(tenant_key);
       }
     });
   }

--- a/tethys_portal/templates/tethys_portal/accounts/sso_tenant.html
+++ b/tethys_portal/templates/tethys_portal/accounts/sso_tenant.html
@@ -29,7 +29,10 @@
         <div class="account-form-body">
           <form id="sso-tenant-form" role="form" method="post">
             {% csrf_token %}
+            {# Backend added as a hidden field to be used in save tenant feature #}
+            <input id="backend" type="hidden" value="{{ backend }}">
             {% bootstrap_form form %}
+            <a class="btn btn-default" href="{% url 'accounts:login' %}">Back</a>
             <button type="submit" id="sso-tenant-submit" class="btn btn-default" name="sso-tenant-submit">Next</button>
           </form>
         </div>

--- a/tethys_portal/urls.py
+++ b/tethys_portal/urls.py
@@ -74,7 +74,7 @@ developer_urls = [
 oauth2_urls = [
     # authentication / association
     url(r'^login/(?P<backend>[^/]+)/$', tethys_portal_psa.auth, name='begin'),
-    url(r'^complete/(?P<backend>[^/]+)/$', psa_views.complete, name='complete'),
+    url(r'^complete/(?P<backend>[^/]+)/$', tethys_portal_psa.complete, name='complete'),
     # disconnection
     url(r'^disconnect/(?P<backend>[^/]+)/$', psa_views.disconnect, name='disconnect'),
     url(r'^disconnect/(?P<backend>[^/]+)/(?P<association_id>\d+)/$', psa_views.disconnect,

--- a/tethys_portal/urls.py
+++ b/tethys_portal/urls.py
@@ -44,7 +44,6 @@ account_urls = [
     url(r'^login/$', tethys_portal_accounts.login_view, name='login'),
     url(r'^logout/$', tethys_portal_accounts.logout_view, name='logout'),
     url(r'^register/$', tethys_portal_accounts.register, name='register'),
-    url(r'^tenant/$', tethys_portal_accounts.sso_tenant, name='sso_tenant'),
     url(r'^password/reset/$', never_cache(PasswordResetView.as_view(
         success_url=reverse_lazy('accounts:password_reset_done'))
     ), name='password_reset'),
@@ -78,7 +77,10 @@ oauth2_urls = [
     url(r'^complete/(?P<backend>[^/]+)/$', psa_views.complete, name='complete'),
     # disconnection
     url(r'^disconnect/(?P<backend>[^/]+)/$', psa_views.disconnect, name='disconnect'),
-    url(r'^disconnect/(?P<backend>[^/]+)/(?P<association_id>\d+)/$', psa_views.disconnect, name='disconnect_individual'),
+    url(r'^disconnect/(?P<backend>[^/]+)/(?P<association_id>\d+)/$', psa_views.disconnect,
+        name='disconnect_individual'),
+    # get tenant name for multi-tenant support
+    url(r'^tenant/(?P<backend>[^/]+)/$', tethys_portal_psa.tenant, name='tenant'),
 ]
 
 # development_error_urls = [

--- a/tethys_portal/urls.py
+++ b/tethys_portal/urls.py
@@ -14,11 +14,13 @@ from django.views.decorators.cache import never_cache
 from django.contrib import admin
 from django.contrib.auth.views import PasswordResetView, PasswordResetDoneView, PasswordResetConfirmView, \
     PasswordResetCompleteView
+from social_django import views as psa_views, urls as psa_urls
 
 from tethys_apps.urls import extension_urls
 
 from tethys_portal.views import accounts as tethys_portal_accounts, developer as tethys_portal_developer, \
-    error as tethys_portal_error, home as tethys_portal_home, user as tethys_portal_user, admin as tethys_portal_admin
+    error as tethys_portal_error, home as tethys_portal_home, user as tethys_portal_user, \
+    admin as tethys_portal_admin, psa as tethys_portal_psa
 from tethys_apps import views as tethys_apps_views
 from tethys_compute.views import dask_dashboard as tethys_dask_views
 
@@ -70,6 +72,15 @@ developer_urls = [
     url(r'^services/', include(('tethys_services.urls', 'services'), namespace='services')),
 ]
 
+oauth2_urls = [
+    # authentication / association
+    url(r'^login/(?P<backend>[^/]+)/$', tethys_portal_psa.auth, name='begin'),
+    url(r'^complete/(?P<backend>[^/]+)/$', psa_views.complete, name='complete'),
+    # disconnection
+    url(r'^disconnect/(?P<backend>[^/]+)/$', psa_views.disconnect, name='disconnect'),
+    url(r'^disconnect/(?P<backend>[^/]+)/(?P<association_id>\d+)/$', psa_views.disconnect, name='disconnect_individual'),
+]
+
 # development_error_urls = [
 #     url(r'^400/$', tethys_portal_error.handler_400, name='error_400'),
 #     url(r'^403/$', tethys_portal_error.handler_403, name='error_403'),
@@ -82,7 +93,7 @@ urlpatterns = [
     url(r'^admin/', admin_urls),
     url(r'^accounts/', include((account_urls, 'accounts'), namespace='accounts')),
     url(r'^captcha/', include('captcha.urls')),
-    url(r'^oauth2/', include('social_django.urls', namespace='social')),
+    url(r'^oauth2/', include((oauth2_urls, psa_urls.app_name), namespace='social')),
     url(r'^user/(?P<username>[\w.@+-]+)/', include((user_urls, 'user'), namespace='user')),
     url(r'^apps/', include('tethys_apps.urls')),
     url(r'^extensions/', include(extension_urls)),

--- a/tethys_portal/views/accounts.py
+++ b/tethys_portal/views/accounts.py
@@ -171,7 +171,8 @@ def reset(request):
         success_url=reverse('accounts:login')
     )
 
-
+# TODO: Move to psa.py
+# TODO: add backend name to URL and decorate with psa decorator?
 @never_cache
 def sso_tenant(request):
     """
@@ -194,7 +195,9 @@ def sso_tenant(request):
                 normalized_tenant = cleaned_tenant.lower()
                 print(f'"{cleaned_tenant}", "{normalized_tenant}"')
                 # TODO: validate that the normalized_tenant given is a valid tenant in settings
-                # TODO: redirect back to the SSO pipeline with correct Tenant
+                # TODO: get settings for matching tenant name
+                # TODO: set settings on backend
+                # TODO: redirect to auth provider to handle auth
     else:
         # Create new empty form
         form = SsoTenantForm()

--- a/tethys_portal/views/accounts.py
+++ b/tethys_portal/views/accounts.py
@@ -199,9 +199,6 @@ def sso_tenant(request):
         # Create new empty form
         form = SsoTenantForm()
 
-    # Set placeholder for tenant text input to be same as tenant_alias
-    form.fields['tenant'].widget.attrs['placeholder'] = tenant_alias
-
     context = {
         'form': form,
         'form_title': tenant_alias,

--- a/tethys_portal/views/accounts.py
+++ b/tethys_portal/views/accounts.py
@@ -8,7 +8,6 @@
 ********************************************************************************
 """
 from django.conf import settings
-from django.http import HttpResponseBadRequest
 from django.urls import reverse
 from django.shortcuts import render, redirect
 from django.contrib.auth import authenticate, login, logout
@@ -16,7 +15,7 @@ from django.contrib.auth.views import PasswordResetView, PasswordResetConfirmVie
 from django.contrib import messages
 from django.views.decorators.cache import never_cache
 from mfa.helpers import has_mfa
-from tethys_portal.forms import LoginForm, RegisterForm, SsoTenantForm
+from tethys_portal.forms import LoginForm, RegisterForm
 from tethys_portal.utilities import log_user_in
 
 
@@ -170,42 +169,3 @@ def reset(request):
         subject_template_name='tethys_portal/accounts/password_reset/reset_subject.txt',
         success_url=reverse('accounts:login')
     )
-
-# TODO: Move to psa.py
-# TODO: add backend name to URL and decorate with psa decorator?
-@never_cache
-def sso_tenant(request):
-    """
-    Handle tenant page request.
-    """
-    # Get SSO_TENANT_ALIAS setting
-    tenant_alias = getattr(settings, 'SSO_TENANT_ALIAS', 'Tenant').title()
-
-    # Handle form
-    if request.method == 'POST':
-        if 'sso-tenant-submit' not in request.POST:
-            return HttpResponseBadRequest()
-        else:
-            # Create form bound to request data
-            form = SsoTenantForm(request.POST)
-
-            # Validate the form
-            if form.is_valid():
-                cleaned_tenant = form.cleaned_data.get('tenant')
-                normalized_tenant = cleaned_tenant.lower()
-                print(f'"{cleaned_tenant}", "{normalized_tenant}"')
-                # TODO: validate that the normalized_tenant given is a valid tenant in settings
-                # TODO: get settings for matching tenant name
-                # TODO: set settings on backend
-                # TODO: redirect to auth provider to handle auth
-    else:
-        # Create new empty form
-        form = SsoTenantForm()
-
-    context = {
-        'form': form,
-        'form_title': tenant_alias,
-        'page_title': tenant_alias
-    }
-
-    return render(request, 'tethys_portal/accounts/sso_tenant.html', context)

--- a/tethys_portal/views/psa.py
+++ b/tethys_portal/views/psa.py
@@ -1,26 +1,57 @@
+import logging
+
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.http import HttpResponseBadRequest
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_exempt
 
 from social_core.utils import setting_name
-from social_core.actions import do_auth
+from social_core.actions import do_auth, do_complete
 from social_django.utils import psa
+from social_django.views import _do_login
 
-from forms import SsoTenantForm
+from tethys_portal.forms import SsoTenantForm
+from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
 
 NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
+log = logging.getLogger(f'tethys.{__name__}')
 
 
 @never_cache
 @psa('social:complete')
 def auth(request, backend):
-    print('CUSTOM SOCIAL AUTH VIEW')
-    # TODO: Detect if multi-tenant applies for given backend
-    # TODO: Redirect to tenant view if multi-tenant applies
-    # TODO: Otherwise call do_auth like normal
+    # Redirect to tenant page if MULTI_TENANT setting configured for supported backend
+    if isinstance(request.backend, MultiTenantMixin) and request.backend.setting('MULTI_TENANT', None) is not None:
+        return redirect('social:tenant', backend=backend)
     return do_auth(request.backend, redirect_name=REDIRECT_FIELD_NAME)
+
+
+@never_cache
+@csrf_exempt
+@psa('social:complete')
+def complete(request, backend, *args, **kwargs):
+    """Authentication complete view"""
+    if isinstance(request.backend, MultiTenantMixin):
+        # Get tenant name from session storage
+        saved_tenant = request.backend.strategy.session_get('tenant')
+        if saved_tenant is None:
+            log.error('Session contains no value for "tenant".')
+            return redirect('accounts:login')
+
+        try:
+            # Setting the tenant on the backend performs normalization and validation of tenant
+            # Part of the validation is that the provided tenant is in the MULTI_TENANT setting.
+            request.backend.tenant = saved_tenant
+        except (ImproperlyConfigured, ValueError) as e:
+            log.error(str(e))
+            return redirect('accounts:login')
+
+    return do_complete(request.backend, _do_login, user=request.user,
+                       redirect_name=REDIRECT_FIELD_NAME, request=request,
+                       *args, **kwargs)
 
 
 @never_cache
@@ -29,7 +60,12 @@ def tenant(request, backend):
     """
     Handle tenant page request.
     """
-    # Get SSO_TENANT_ALIAS setting
+    # Send back to login of tenant page accessed for non-multi-tenant backend
+    if not isinstance(request.backend, MultiTenantMixin):
+        log.error(f'Backend "{type(request.backend)}" does not support MULTI_TENANT features.')
+        return redirect('accounts:login')
+
+    # Get the Tenant alias to use for titles in the form
     tenant_alias = getattr(settings, 'SSO_TENANT_ALIAS', 'Tenant').title()
 
     # Handle form
@@ -43,12 +79,21 @@ def tenant(request, backend):
             # Validate the form
             if form.is_valid():
                 cleaned_tenant = form.cleaned_data.get('tenant')
-                normalized_tenant = cleaned_tenant.lower()
-                print(f'"{cleaned_tenant}", "{normalized_tenant}"')
-                # TODO: validate that the normalized_tenant given is a valid tenant in settings
-                # TODO: get settings for matching tenant name
-                # TODO: set settings on backend
-                # TODO: redirect to auth provider to handle auth
+
+                try:
+                    # Setting the tenant on the backend performs normalization and validation of tenant
+                    # Part of the validation is that the provided tenant is in the MULTI_TENANT setting.
+                    request.backend.tenant = cleaned_tenant
+                    response = do_auth(request.backend, redirect_name=REDIRECT_FIELD_NAME)
+                    return response
+                except ImproperlyConfigured as e:
+                    # No MULTI_TENANT settings configured: log error and redirect back to login view
+                    log.error(str(e))
+                    return redirect('accounts:login')
+                except ValueError:
+                    # Set form error and re-render form
+                    form.add_error('tenant', f'Invalid {tenant_alias.lower()} provided.')
+
     else:
         # Create new empty form
         form = SsoTenantForm()
@@ -56,7 +101,8 @@ def tenant(request, backend):
     context = {
         'form': form,
         'form_title': tenant_alias,
-        'page_title': tenant_alias
+        'page_title': tenant_alias,
+        'backend': backend
     }
 
     return render(request, 'tethys_portal/accounts/sso_tenant.html', context)

--- a/tethys_portal/views/psa.py
+++ b/tethys_portal/views/psa.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.views.decorators.cache import never_cache
+
+from social_core.utils import setting_name
+from social_core.actions import do_auth
+from social_django.utils import psa
+
+NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
+
+
+@never_cache
+@psa('social:complete')
+def auth(request, backend):
+    print('CUSTOM SOCIAL AUTH VIEW')
+    # TODO: Detect if multi-tenant applies for given backend
+    # TODO: Redirect to tenant view if multi-tenant applies
+    # TODO: Otherwise call do_auth like normal
+    return do_auth(request.backend, redirect_name=REDIRECT_FIELD_NAME)
+
+# TODO: implement custom versions of the other methods? complete, disconnect, disconnect single

--- a/tethys_portal/views/psa.py
+++ b/tethys_portal/views/psa.py
@@ -1,10 +1,14 @@
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.http import HttpResponseBadRequest
+from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 
 from social_core.utils import setting_name
 from social_core.actions import do_auth
 from social_django.utils import psa
+
+from forms import SsoTenantForm
 
 NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
 
@@ -17,5 +21,44 @@ def auth(request, backend):
     # TODO: Redirect to tenant view if multi-tenant applies
     # TODO: Otherwise call do_auth like normal
     return do_auth(request.backend, redirect_name=REDIRECT_FIELD_NAME)
+
+
+@never_cache
+@psa('social:complete')
+def tenant(request, backend):
+    """
+    Handle tenant page request.
+    """
+    # Get SSO_TENANT_ALIAS setting
+    tenant_alias = getattr(settings, 'SSO_TENANT_ALIAS', 'Tenant').title()
+
+    # Handle form
+    if request.method == 'POST':
+        if 'sso-tenant-submit' not in request.POST:
+            return HttpResponseBadRequest()
+        else:
+            # Create form bound to request data
+            form = SsoTenantForm(request.POST)
+
+            # Validate the form
+            if form.is_valid():
+                cleaned_tenant = form.cleaned_data.get('tenant')
+                normalized_tenant = cleaned_tenant.lower()
+                print(f'"{cleaned_tenant}", "{normalized_tenant}"')
+                # TODO: validate that the normalized_tenant given is a valid tenant in settings
+                # TODO: get settings for matching tenant name
+                # TODO: set settings on backend
+                # TODO: redirect to auth provider to handle auth
+    else:
+        # Create new empty form
+        form = SsoTenantForm()
+
+    context = {
+        'form': form,
+        'form_title': tenant_alias,
+        'page_title': tenant_alias
+    }
+
+    return render(request, 'tethys_portal/accounts/sso_tenant.html', context)
 
 # TODO: implement custom versions of the other methods? complete, disconnect, disconnect single

--- a/tethys_portal/views/psa.py
+++ b/tethys_portal/views/psa.py
@@ -62,7 +62,7 @@ def tenant(request, backend):
     """
     # Send back to login of tenant page accessed for non-multi-tenant backend
     if not isinstance(request.backend, MultiTenantMixin):
-        log.error(f'Backend "{type(request.backend)}" does not support MULTI_TENANT features.')
+        log.error(f'Backend "{request.backend.name}" does not support MULTI_TENANT features.')
         return redirect('accounts:login')
 
     # Get the Tenant alias to use for titles in the form

--- a/tethys_services/backends/adfs.py
+++ b/tethys_services/backends/adfs.py
@@ -1,7 +1,9 @@
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 
+from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
 
-class ADFSOpenIdConnect(OpenIdConnectAuth):
+
+class ADFSOpenIdConnect(MultiTenantMixin, OpenIdConnectAuth):
     """AD FS 4.0+ OpenIDConnect authentication backend."""
     name = 'adfs-oidc'
 

--- a/tethys_services/backends/adfs.py
+++ b/tethys_services/backends/adfs.py
@@ -3,7 +3,7 @@ from social_core.backends.open_id_connect import OpenIdConnectAuth
 from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
 
 
-class ADFSOpenIdConnect(MultiTenantMixin, OpenIdConnectAuth):
+class ADFSOpenIdConnect(OpenIdConnectAuth):
     """AD FS 4.0+ OpenIDConnect authentication backend."""
     name = 'adfs-oidc'
 
@@ -18,3 +18,7 @@ class ADFSOpenIdConnect(MultiTenantMixin, OpenIdConnectAuth):
             subdomain = subdomain[0:-1]
 
         return subdomain + '/adfs'
+
+
+class ADFSOpenIdConnectMultiTenant(MultiTenantMixin, ADFSOpenIdConnect):
+    pass

--- a/tethys_services/backends/azuread.py
+++ b/tethys_services/backends/azuread.py
@@ -1,0 +1,12 @@
+from social_core.backends.azuread_tenant import AzureADTenantOAuth2
+from social_core.backends.azuread_b2c import AzureADB2COAuth2
+
+from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
+
+
+class AzureADTenantOAuth2MultiTenant(MultiTenantMixin, AzureADTenantOAuth2):
+    pass
+
+
+class AzureADB2COAuth2MultiTenant(MultiTenantMixin, AzureADB2COAuth2):
+    pass

--- a/tethys_services/backends/multi_tenant_mixin.py
+++ b/tethys_services/backends/multi_tenant_mixin.py
@@ -30,10 +30,7 @@ class MultiTenantMixin:
             if not multi_tenant_settings:
                 return None
 
-            try:
-                self._tenant_settings = multi_tenant_settings.get(self._tenant)
-            except KeyError:
-                return None
+            self._tenant_settings = multi_tenant_settings.get(self._tenant)
         return self._tenant_settings
 
     @property
@@ -65,7 +62,7 @@ class MultiTenantMixin:
         multi_tenant_setting_name = setting_name(self.name, 'MULTI_TENANT')
         multi_tenant_settings = self.setting('MULTI_TENANT')
         if not multi_tenant_settings:
-            raise ImproperlyConfigured(f'Backend "{type(self)}" not configured for multi-tenant: '
+            raise ImproperlyConfigured(f'Backend "{self.name}" not configured for multi-tenant: '
                                        f'{multi_tenant_setting_name} setting not found.')
         if normalized_tenant not in multi_tenant_settings:
             raise ValueError(f'Tenant "{normalized_tenant}" not found in {multi_tenant_setting_name}.')

--- a/tethys_services/backends/multi_tenant_mixin.py
+++ b/tethys_services/backends/multi_tenant_mixin.py
@@ -1,0 +1,73 @@
+from django.core.exceptions import ImproperlyConfigured
+from social_core.utils import setting_name
+
+
+class MultiTenantMixin:
+    """Mixin class that adds support for multi-tenant use. Note must be used with BaseAuth class."""
+    _tenant = None
+    _tenant_settings = None
+
+    def setting(self, name, default=None):
+        """Return setting from tenant_settings if found there, otherwise default behavior."""
+        # If the setting is in the MULTI_TENANT settings, return that value
+        expanded_setting_name = setting_name(self.name, name)
+        if name != 'MULTI_TENANT' and self.tenant_settings and expanded_setting_name in self.tenant_settings:
+            return self.tenant_settings.get(expanded_setting_name)
+        return super().setting(name, default)
+
+    @property
+    def tenant_settings(self):
+        """
+        Lazy loading getter for _tenant_settings.
+        Returns:
+            dict: the settings for self._tenant. Returns None if no MULTI_TENANT settings, tenant not set, or tenant can't be found in MULTI_TENANT settings.
+        """  # noqa: E501
+        if not self.tenant:
+            return None
+
+        if self._tenant_settings is None:
+            multi_tenant_settings = self.setting('MULTI_TENANT')
+            if not multi_tenant_settings:
+                return None
+
+            try:
+                self._tenant_settings = multi_tenant_settings.get(self._tenant)
+            except KeyError:
+                return None
+        return self._tenant_settings
+
+    @property
+    def tenant(self):
+        """
+        Getter for the _tenant property.
+
+        Returns:
+            str: value of self._tenant or None if not set.
+        """
+        return self._tenant
+
+    @tenant.setter
+    def tenant(self, val):
+        """
+        Normalize and validate the tenant name provided by user and set _tenant (e.g.: "GitHub" -> "github"). Validation includes verifying that the tenant is included in the MULTI_TENANT settings.
+
+        Args:
+            val (str): the raw tenant name (e.g.: GitHub).
+
+        Raises:
+            ImproperlyConfigured: if the backend-namespaced MULTI_TENANT setting cannot be found for validation.
+            ValueError: if the normalized tenant string con't be found in the backend-namespaced MULTI_TENANT setting.
+        """  # noqa: E501
+        # Normalize before saving
+        normalized_tenant = val.lower()
+
+        # Validate tenant before saving
+        multi_tenant_setting_name = setting_name(self.name, 'MULTI_TENANT')
+        multi_tenant_settings = self.setting('MULTI_TENANT')
+        if not multi_tenant_settings:
+            raise ImproperlyConfigured(f'Backend "{type(self)}" not configured for multi-tenant: '
+                                       f'{multi_tenant_setting_name} setting not found.')
+        if normalized_tenant not in multi_tenant_settings:
+            raise ValueError(f'Tenant "{normalized_tenant}" not found in {multi_tenant_setting_name}.')
+
+        self._tenant = normalized_tenant

--- a/tethys_services/backends/okta.py
+++ b/tethys_services/backends/okta.py
@@ -1,0 +1,12 @@
+from social_core.backends.okta import OktaOAuth2
+from social_core.backends.okta_openidconnect import OktaOpenIdConnect
+
+from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
+
+
+class OktaOauth2MultiTenant(MultiTenantMixin, OktaOAuth2):
+    pass
+
+
+class OktaOpenIdConnectMultiTenant(MultiTenantMixin, OktaOpenIdConnect):
+    pass

--- a/tethys_services/backends/onelogin.py
+++ b/tethys_services/backends/onelogin.py
@@ -8,7 +8,7 @@ from social_core.exceptions import AuthTokenError
 from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
 
 
-class OneLoginOIDC(MultiTenantMixin, OpenIdConnectAuth):
+class OneLoginOIDC(OpenIdConnectAuth):
     """OneLogin OpenIDConnect authentication backend."""
     name = 'onelogin-oidc'
 
@@ -64,3 +64,7 @@ class OneLoginOIDC(MultiTenantMixin, OpenIdConnectAuth):
             raise AuthTokenError(self, 'Invalid signature')
 
         self.validate_claims(claims)
+
+
+class OneLoginOIDCMultiTenant(MultiTenantMixin, OneLoginOIDC):
+    pass

--- a/tethys_services/backends/onelogin.py
+++ b/tethys_services/backends/onelogin.py
@@ -5,8 +5,10 @@ from jose.constants import ALGORITHMS
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 from social_core.exceptions import AuthTokenError
 
+from tethys_services.backends.multi_tenant_mixin import MultiTenantMixin
 
-class OneLoginOIDC(OpenIdConnectAuth):
+
+class OneLoginOIDC(MultiTenantMixin, OpenIdConnectAuth):
     """OneLogin OpenIDConnect authentication backend."""
     name = 'onelogin-oidc'
 


### PR DESCRIPTION
Implements full flow for multi-tenant authentication.
* Moves `sso_tenant` view to new psa.py view module and renames it to `tenant`.
* Adds psa URLs manually so we can override with custom own versions of the views.
* Implements custom `auth` and `complete` views that check for multi-tenant conditions and adds tenant to the `backend` for use looking up tenant-specific settings later on.
* Completes implementation of `tenant` view so that it calls `do_auth` when tenant info has been set on the backend.
* Adds `SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ['tenant']` to `settings.py` so that the `tenant` field of the tenant form will be saved in the session storage. The value is retrieved in `complete` view to load the tenant settings on callback.
* Adds `MultiTenantMixin` class to add to backends so they can support multi-tenant authentication.
* Adds backend "namespace" to local storage keys so that the tenant name that is saved for one backend isn't populated in the Tenant form for another backend.

Implements client feedback
* Add setting to override the regex used to validate the tenant field (`SSO_TENANT_REGEX`)

- [x] Linted
- [x] 100% test coverage
- [x] Test cover all common cases
- [x] Doctstring on new methods and classes